### PR TITLE
Add cross-package dependency support

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -19,7 +19,7 @@ runs:
       python3-debian
       python3-requests
       python3-xdg
-      python3-falcon
+      python3-flask
     shell: bash
   - name: Install Python dependencies
     # This is done with sudo so that packages are installed system-wide. This

--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -19,6 +19,7 @@ runs:
       python3-debian
       python3-requests
       python3-xdg
+      python3-falcon
     shell: bash
   - name: Install Python dependencies
     # This is done with sudo so that packages are installed system-wide. This

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/install-dependencies
       - name: Run tests
-        run: pytest .
+        run: pytest --capture=no --verbose .

--- a/debutizer/__main__.py
+++ b/debutizer/__main__.py
@@ -10,9 +10,19 @@ def main():
     """An exception handling wrapper around the real entrypoint, _main"""
     try:
         _main()
-    except CommandError as ex:
+    except (CommandError, KeyboardInterrupt) as ex:
         print("")
-        print_color(ex.message, color=Color.RED, format_=Format.BOLD, file=sys.stderr)
+        if isinstance(ex, KeyboardInterrupt):
+            print_color(
+                "Interrupted by SIGINT",
+                color=Color.RED,
+                format_=Format.BOLD,
+                file=sys.stderr,
+            )
+        else:
+            print_color(
+                ex.message, color=Color.RED, format_=Format.BOLD, file=sys.stderr
+            )
         if "DEBUTIZER_SHOW_TRACEBACKS" in os.environ:
             raise ex
         else:

--- a/debutizer/commands/artifacts.py
+++ b/debutizer/commands/artifacts.py
@@ -44,7 +44,7 @@ SOURCE_ARCHIVE_GLOB = "*.orig.tar.*"
 DEBIAN_ARCHIVE_GLOB = "*.debian.tar.*"
 
 
-_SOURCE_ARCHIVE_REGEX = re.compile("^.*\.orig\.tar\.[a-zA-Z]+$")
+_SOURCE_ARCHIVE_REGEX = re.compile(r"^.*\.orig\.tar\.[a-zA-Z]+$")
 """A more specific version of the source archive glob that filters out files that aren't
 actually archives, like mypackage.orig.tar.gz.asc.
 """

--- a/debutizer/commands/build.py
+++ b/debutizer/commands/build.py
@@ -48,6 +48,7 @@ class BuildCommand(Command):
         registry = Registry()
         local_repo = LocalRepository(port=8080, artifacts_dir=args.artifacts_dir)
         local_repo.start()
+        self.cleanup_hooks.append(local_repo.close)
 
         Environment.codename = args.distribution
         Environment.architecture = args.architecture

--- a/debutizer/commands/build.py
+++ b/debutizer/commands/build.py
@@ -132,8 +132,6 @@ class BuildCommand(Command):
             add_sources_files(args.artifacts_dir)
             add_release_files(args.artifacts_dir, sign=False, gpg_key_id=None)
 
-        local_repo.close()
-
         print("")
         print_done("Build")
 

--- a/debutizer/commands/build.py
+++ b/debutizer/commands/build.py
@@ -11,14 +11,17 @@ from ..registry import Registry
 from ..source_package import SourcePackage
 from ..upstreams import Upstream
 from .command import Command
+from .local_repo import LocalRepository
+from .repo_metadata import add_packages_files, add_release_files, add_sources_files
 from .utils import (
     build_package,
     copy_binary_artifacts,
     copy_source_artifacts,
-    get_package_dirs,
+    find_package_dirs,
     make_chroot,
     make_source_files,
     process_package_pys,
+    set_chroot_repos,
 )
 
 
@@ -41,7 +44,10 @@ class BuildCommand(Command):
         )
 
     def behavior(self, args: argparse.Namespace) -> None:
+        args.artifacts_dir.mkdir(exist_ok=True)
         registry = Registry()
+        local_repo = LocalRepository(port=8080, artifacts_dir=args.artifacts_dir)
+        local_repo.start()
 
         Environment.codename = args.distribution
         Environment.architecture = args.architecture
@@ -54,7 +60,7 @@ class BuildCommand(Command):
         Upstream.build_root = args.build_dir
         SourcePackage.distribution = args.distribution
 
-        package_dirs = get_package_dirs(args.package_dir)
+        package_dirs = find_package_dirs(args.package_dir)
         chroot_archive_path = make_chroot(args.distribution)
         package_pys = process_package_pys(package_dirs, registry, args.build_dir)
 
@@ -70,13 +76,33 @@ class BuildCommand(Command):
                     new_package_pys.append(package_py)
             package_pys = new_package_pys
 
+        print("")
+        print_color(
+            "Building the following packages in this order:",
+            color=Color.MAGENTA,
+            format_=Format.BOLD,
+        )
         for package_py in package_pys:
+            print(f" * {package_py.source_package.name}")
+
+        for i, package_py in enumerate(package_pys):
             print("")
             print_color(
                 f"Building {package_py.source_package.name}",
                 color=Color.MAGENTA,
                 format_=Format.BOLD,
             )
+
+            if i == 0:
+                # This is the first package being built, and APT does not like empty
+                # repositories
+                repositories = []
+            else:
+                repositories = [
+                    f"deb [trusted=yes] http://localhost:8080 {args.distribution} main",
+                ]
+
+            set_chroot_repos(args.distribution, repositories)
 
             source_results_dir = make_source_files(
                 args.build_dir, package_py.source_package
@@ -100,6 +126,12 @@ class BuildCommand(Command):
                 component=package_py.component,
                 architecture=args.architecture,
             )
+
+            add_packages_files(args.artifacts_dir)
+            add_sources_files(args.artifacts_dir)
+            add_release_files(args.artifacts_dir, sign=False, gpg_key_id=None)
+
+        local_repo.close()
 
         print("")
         print_done("Build")

--- a/debutizer/commands/command.py
+++ b/debutizer/commands/command.py
@@ -10,6 +10,8 @@ from xdg.BaseDirectory import save_cache_path
 
 
 class Command(ABC):
+    """A Debutizer CLI command"""
+
     parser: argparse.ArgumentParser
     subcommands: Dict[str, "Command"] = {}
 

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -27,7 +27,6 @@ class LocalRepository:
             app=self._app,
             handler_class=simple_server.WSGIRequestHandler,
         )
-        self._server.allow_reuse_address = True
 
         self._thread = Thread(
             name="Local Repository",
@@ -39,5 +38,6 @@ class LocalRepository:
         self._thread.start()
 
     def close(self):
+        self._server.server_close()
         self._server.shutdown()
         self._thread.join()

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -15,6 +15,7 @@ class LocalRepository:
             ("", port),
             functools.partial(SimpleHTTPRequestHandler, directory=artifacts_dir),
         )
+        self._server.allow_reuse_address = True
 
         self._thread = Thread(
             name="Local Repository",
@@ -26,4 +27,4 @@ class LocalRepository:
         self._thread.start()
 
     def close(self):
-        self._server.server_close()
+        self._server.shutdown()

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -2,10 +2,9 @@ from pathlib import Path
 from threading import Thread
 from wsgiref import simple_server
 
-import falcon
+import flask
 
-
-# TODO: Consider using http.server instead of Falcon when Python 3.6 is no
+# TODO: Consider using http.server instead of Flask when Python 3.6 is no
 #       longer supported
 
 
@@ -16,14 +15,16 @@ class LocalRepository:
 
     def __init__(self, port: int, artifacts_dir: Path):
         self._artifacts_dir = artifacts_dir
-        self._api= falcon.API()
+        self._app = flask.Flask(__name__)
 
-        self._api.add_static_route("/", str(self._artifacts_dir))
+        @self._app.route("/<path:path>")
+        def static_files(path: str) -> flask.Response:
+            return flask.send_from_directory(self._artifacts_dir, path)
 
         self._server = simple_server.make_server(
             "0.0.0.0",
             port,
-            app=self._api,
+            app=self._app,
             handler_class=simple_server.WSGIRequestHandler,
         )
 

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -1,0 +1,29 @@
+import functools
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+
+class LocalRepository:
+    """Hosts an APT repository based on the contents in the artifacts dir. This allows
+    Debutizer packages to download other Debutizer packages as dependencies.
+    """
+
+    def __init__(self, port: int, artifacts_dir: Path):
+        self._artifacts_dir = artifacts_dir
+        self._server = ThreadingHTTPServer(
+            ("", port),
+            functools.partial(SimpleHTTPRequestHandler, directory=artifacts_dir),
+        )
+
+        self._thread = Thread(
+            name="Local Repository",
+            target=self._server.serve_forever,
+            daemon=True,
+        )
+
+    def start(self):
+        self._thread.start()
+
+    def close(self):
+        self._server.server_close()

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -16,14 +16,14 @@ class LocalRepository:
 
     def __init__(self, port: int, artifacts_dir: Path):
         self._artifacts_dir = artifacts_dir
-        self._app = falcon.App()
+        self._api= falcon.API()
 
-        self._app.add_static_route("/", str(self._artifacts_dir))
+        self._api.add_static_route("/", str(self._artifacts_dir))
 
         self._server = simple_server.make_server(
             "0.0.0.0",
             port,
-            app=self._app,
+            app=self._api,
             handler_class=simple_server.WSGIRequestHandler,
         )
 

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -27,6 +27,7 @@ class LocalRepository:
             app=self._app,
             handler_class=simple_server.WSGIRequestHandler,
         )
+        self._server.allow_reuse_address = True
 
         self._thread = Thread(
             name="Local Repository",

--- a/debutizer/commands/local_repo.py
+++ b/debutizer/commands/local_repo.py
@@ -27,6 +27,7 @@ class LocalRepository:
             app=self._app,
             handler_class=simple_server.WSGIRequestHandler,
         )
+        self._server.allow_reuse_address = True
 
         self._thread = Thread(
             name="Local Repository",
@@ -38,6 +39,6 @@ class LocalRepository:
         self._thread.start()
 
     def close(self):
-        self._server.server_close()
         self._server.shutdown()
+        self._server.server_close()
         self._thread.join()

--- a/debutizer/commands/pbuilder_hooks/D70results
+++ b/debutizer/commands/pbuilder_hooks/D70results
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Makes pbuilder update the package list before installing build dependencies.
+# This is necessary since we add a local APT repository to the source list.
+
+echo "Updating the package list..."
+apt-get update

--- a/debutizer/commands/repo_metadata/sources.py
+++ b/debutizer/commands/repo_metadata/sources.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import List
 
 from debutizer.print_utils import Color, Format, print_color
-
 from debutizer.subprocess_utils import run
+
 from .utils import save_metadata_files
 
 

--- a/debutizer/commands/repo_metadata/utils.py
+++ b/debutizer/commands/repo_metadata/utils.py
@@ -1,0 +1,25 @@
+import gzip
+from pathlib import Path
+from typing import List
+
+
+def save_metadata_files(path: Path, contents: str) -> List[Path]:
+    """Saves the metadata file and the corresponding compressed version of the
+    file.
+
+    :param path: The path to save the uncompressed metadata file at
+    :param contents: The data to save
+    :return: The newly created files
+    """
+    new_files = []
+
+    contents_bytes = contents.encode()
+    path.write_bytes(contents_bytes)
+    new_files.append(path)
+
+    compressed_file = path.with_suffix(".gz")
+    with gzip.open(compressed_file, "wb") as f:
+        f.write(contents_bytes)
+    new_files.append(compressed_file)
+
+    return new_files

--- a/debutizer/commands/root.py
+++ b/debutizer/commands/root.py
@@ -6,6 +6,10 @@ from .command import Command
 
 
 class RootCommand(Command):
+    """The command at the root of the command tree. All top-level commands, like
+    'debutizer build', are a subcommand of this command.
+    """
+
     def __init__(self):
         self.parser = argparse.ArgumentParser(
             prog="debutizer",

--- a/debutizer/commands/s3_repo/upload.py
+++ b/debutizer/commands/s3_repo/upload.py
@@ -17,8 +17,8 @@ import requests
 
 from debutizer.errors import CommandError, UnexpectedError
 from debutizer.print_utils import print_done
-
 from debutizer.subprocess_utils import run
+
 from ..artifacts import find_archives
 from ..command import Command
 from ..repo_metadata import add_packages_files, add_release_files, add_sources_files

--- a/debutizer/commands/source.py
+++ b/debutizer/commands/source.py
@@ -8,7 +8,7 @@ from ..upstreams import Upstream
 from .command import Command
 from .utils import (
     copy_source_artifacts,
-    get_package_dirs,
+    find_package_dirs,
     make_source_files,
     process_package_pys,
 )
@@ -17,7 +17,7 @@ from .utils import (
 class SourceCommand(Command):
     def __init__(self):
         self.parser = argparse.ArgumentParser(
-            prog="debutizer source", description="Fetches and sources your APT packages"
+            prog="debutizer source", description="Fetches and sources APT packages"
         )
 
         self.add_common_args()
@@ -33,7 +33,7 @@ class SourceCommand(Command):
         Upstream.build_root = args.build_dir
         SourcePackage.distribution = args.distribution
 
-        package_dirs = get_package_dirs(args.package_dir)
+        package_dirs = find_package_dirs(args.package_dir)
         package_pys = process_package_pys(package_dirs, registry, args.build_dir)
 
         for package_py in package_pys:

--- a/debutizer/compat.py
+++ b/debutizer/compat.py
@@ -1,32 +1,15 @@
 from pathlib import Path
 from typing import Optional
 
-from .environment import Environment
-from .errors import CommandError, UnexpectedError
+from .errors import CommandError
 
 
 class Compat:
-    version: Optional[int]
+    version: Optional[str]
 
     def __init__(self, package_dir: Path):
         self.version = None
         self._package_dir = package_dir
-
-    def from_distribution(self) -> None:
-        """Use the debhelper compatibility version used by the current distribution"""
-        if Environment.codename is None:
-            raise UnexpectedError("The Environment.codename field must be set")
-
-        if Environment.codename in ["bionic"]:
-            self.version = 11
-        elif Environment.codename in ["focal", "buster"]:
-            self.version = 12
-        elif Environment.codename in ["groovy", "hirsute", "impish", "bullseye"]:
-            self.version = 13
-        else:
-            raise UnexpectedError(f"Unknown distribution: {Environment.codename}")
-
-        self.save()
 
     def load(self, complete: bool):
         compat_file = self._package_dir / "debian" / "compat"
@@ -34,11 +17,11 @@ class Compat:
         if compat_file.is_file():
             compat_str = compat_file.read_text().strip()
             try:
-                self.version = int(compat_str)
+                self.version = compat_str
             except ValueError as ex:
                 raise CommandError(f"While parsing the compat file: {ex}") from ex
 
     def save(self):
         if self.version is not None:
             compat_file = self._package_dir / "debian" / "compat"
-            compat_file.write_text(str(self.version))
+            compat_file.write_text(self.version)

--- a/debutizer/package_py.py
+++ b/debutizer/package_py.py
@@ -75,3 +75,6 @@ class PackagePy:
         self.component = getattr(package_module, "component", "main")
         if not isinstance(self.component, str):
             raise CommandError("The component variable must be a string")
+
+    def __repr__(self) -> str:
+        return f"PackagePy(source_package={self.source_package})"

--- a/debutizer/relation.py
+++ b/debutizer/relation.py
@@ -34,16 +34,16 @@ class Dependency:
     def deserialize(cls, relation: "PkgRelation.ParsedRelation") -> "Dependency":
         version = None
         relationship = None
-        if relation["version"] is not None:
+        if relation.get("version") is not None:
             relationship, version = relation["version"]
 
         return Dependency(
             name=relation["name"],
-            archqual=relation["archqual"],
+            archqual=relation.get("archqual"),
             version=version,
             relationship=relationship,
-            arch=relation["arch"],
-            restrictions=relation["restrictions"],
+            arch=relation.get("arch"),
+            restrictions=relation.get("restrictions"),
         )
 
     def serialize(self) -> "PkgRelation.ParsedRelation":

--- a/debutizer/relation.py
+++ b/debutizer/relation.py
@@ -63,6 +63,7 @@ class Dependency:
 class Relation:
     def __init__(self, dependencies: List[Dependency]):
         self._dependencies = dependencies
+        self._iter_index = 0
 
     def __len__(self) -> int:
         return len(self._dependencies)
@@ -75,6 +76,18 @@ class Relation:
 
     def __contains__(self, key: int) -> bool:
         return key in self._dependencies
+
+    def __iter__(self) -> "Relation":
+        self._iter_index = 0
+        return self
+
+    def __next__(self) -> Dependency:
+        if self._iter_index >= len(self._dependencies):
+            raise StopIteration
+
+        output = self._dependencies[self._iter_index]
+        self._iter_index += 1
+        return output
 
     def __repr__(self) -> str:
         dependency_list = ", ".join(str(d) for d in self._dependencies)
@@ -123,6 +136,7 @@ class Relation:
 class PackageRelations:
     def __init__(self, relations: List[Relation]):
         self._relations = relations
+        self._iter_index = 0
 
     def __len__(self) -> int:
         return len(self._relations)
@@ -135,6 +149,17 @@ class PackageRelations:
 
     def __contains__(self, key: int) -> bool:
         return key in self._relations
+
+    def __iter__(self) -> "PackageRelations":
+        self._iter_index = 0
+        return self
+
+    def __next__(self) -> Relation:
+        if self._iter_index >= len(self._relations):
+            raise StopIteration
+        value = self._relations[self._iter_index]
+        self._iter_index += 1
+        return value
 
     def add_relation(self, new: Relation, replace: bool = False) -> None:
         conflicting = [r for r in self._relations if r.intersects(new)]

--- a/debutizer/source_paragraph.py
+++ b/debutizer/source_paragraph.py
@@ -80,6 +80,21 @@ class SourceParagraph(Deb822Schema):
             vcs_type_value=vcs_type_value,
         )
 
+    def all_build_depends(self) -> PackageRelations:
+        all_relations = PackageRelations([])
+
+        if self.build_depends is not None:
+            for relation in self.build_depends:
+                all_relations.add_relation(relation, replace=True)
+        if self.build_depends_indep:
+            for relation in self.build_depends_indep:
+                all_relations.add_relation(relation, replace=True)
+        if self.build_depends_arch:
+            for relation in self.build_depends_arch:
+                all_relations.add_relation(relation, replace=True)
+
+        return all_relations
+
     FIELDS = {
         "source": Field("Source"),
         "maintainer": Field("Maintainer"),

--- a/debutizer/subprocess_utils.py
+++ b/debutizer/subprocess_utils.py
@@ -28,7 +28,8 @@ def run(
         root_command = shlex.split(root_command_str)
         command_no_path = root_command + command_no_path
 
-    command_str = shlex.join(command_no_path)
+    # TODO: Use shlex.join when Python 3.8 is the oldest supported version
+    command_str = " ".join(command_no_path)
     print_color(f"> {command_str}", format_=Format.BOLD)
 
     try:

--- a/debutizer/upstreams/local.py
+++ b/debutizer/upstreams/local.py
@@ -34,7 +34,7 @@ class LocalUpstream(Upstream):
                 "--gzip",
                 f"--file={self.name}_{self.version.upstream_version}.orig.tar.gz",
                 f"--directory={build_dir}",
-                str(package_dir.relative_to(build_dir)),
+                package_dir.relative_to(build_dir),
             ],
             on_failure="Failed to compress the local source",
             cwd=build_dir,

--- a/debutizer/upstreams/source_repository.py
+++ b/debutizer/upstreams/source_repository.py
@@ -37,7 +37,7 @@ class SourceRepositoryUpstream(Upstream):
                 "--recurse-submodules",
                 f"--branch={revision}",
                 self.repository_url,
-                str(package_dir),
+                package_dir,
             ],
             on_failure="Failed to clone the upstream source",
         )
@@ -53,7 +53,7 @@ class SourceRepositoryUpstream(Upstream):
                 "--gzip",
                 f"--file={self.name}_{self.version.upstream_version}.orig.tar.gz",
                 f"--directory={build_dir}",
-                str(package_dir.relative_to(build_dir)),
+                package_dir.relative_to(build_dir),
             ],
             on_failure="Failed to compress the upstream source",
             cwd=build_dir,

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,5 +12,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 # Type information is not available in all supported versions of flask
-[flask.*]
+[mypy-flask.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,3 +10,7 @@ ignore_missing_imports = True
 # Type information is not available in all supported versions of python-debian
 [mypy-debian.*]
 ignore_missing_imports = True
+
+# Type information is not available in all supported versions of flask
+[flask.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "python-debian",
         "pyxdg",
         "requests",
+        "falcon",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "python-debian",
         "pyxdg",
         "requests",
-        "falcon",
+        "flask",
     ],
     extras_require={
         "dev": [

--- a/tests/integration/upstreams/test_local.py
+++ b/tests/integration/upstreams/test_local.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from debutizer.commands.build import BuildCommand
 
@@ -17,4 +18,5 @@ def test_build_source_package_upstream_package():
             architecture="amd64",
             upstream_repo=None,
         )
-        command.behavior(args)
+        command.parse_args = Mock(return_value=args)
+        command.run()

--- a/tests/integration/upstreams/test_source_package.py
+++ b/tests/integration/upstreams/test_source_package.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from debutizer.commands.build import BuildCommand
 
@@ -17,4 +18,5 @@ def test_build_source_package_upstream_package():
             architecture="amd64",
             upstream_repo=None,
         )
-        command.behavior(args)
+        command.parse_args = Mock(return_value=args)
+        command.run()

--- a/tests/integration/upstreams/test_source_repository.py
+++ b/tests/integration/upstreams/test_source_repository.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from debutizer.commands.build import BuildCommand
 
@@ -17,4 +18,5 @@ def test_build_source_repository_upstream_package():
             architecture="amd64",
             upstream_repo=None,
         )
-        command.behavior(args)
+        command.parse_args = Mock(return_value=args)
+        command.run()

--- a/tests/resources/local_upstreams/debutizer/package.py
+++ b/tests/resources/local_upstreams/debutizer/package.py
@@ -92,7 +92,7 @@ source_package.copyright.add_license(
         license_=Copyright.full_license_text("BSD-3-Clause"),
     )
 )
-source_package.compat.from_distribution()
+source_package.set_debhelper_compat_version()
 
 source_package.changelog.add(
     version="0.2.0-1",

--- a/tests/resources/local_upstreams/debutizer/package.py
+++ b/tests/resources/local_upstreams/debutizer/package.py
@@ -39,6 +39,7 @@ source_package.control.set_source(
                 "python3-debian",
                 "python3-xdg",
                 "python3-requests",
+                "python3-falcon",
                 "s3fs",
             ]
         ),

--- a/tests/resources/local_upstreams/debutizer/package.py
+++ b/tests/resources/local_upstreams/debutizer/package.py
@@ -39,7 +39,7 @@ source_package.control.set_source(
                 "python3-debian",
                 "python3-xdg",
                 "python3-requests",
-                "python3-falcon",
+                "python3-flask",
                 "s3fs",
             ]
         ),

--- a/tests/unit/test_cleanup_hooks.py
+++ b/tests/unit/test_cleanup_hooks.py
@@ -1,0 +1,42 @@
+import argparse
+from abc import ABC
+from threading import Event
+
+from debutizer.commands import Command
+
+
+def test_cleanup_hooks_run():
+    hook_run = Event()
+
+    class HookCommand(NoArgsCommand):
+        def behavior(self, args: argparse.Namespace) -> None:
+            self.cleanup_hooks.append(hook_run.set)
+
+    command = HookCommand()
+    command.run()
+
+    assert hook_run.is_set()
+
+
+def test_cleanup_hooks_ignore_errors():
+    class FailingCommand(NoArgsCommand):
+        def behavior(self, args: argparse.Namespace) -> None:
+            self.cleanup_hooks.append(self._do_failing_action)
+
+        def _do_failing_action(self) -> None:
+            raise RuntimeError("Oh no!")
+
+    command = FailingCommand()
+    command.run()
+
+
+class NoArgsCommand(Command, ABC):
+    """A version of Command that avoids defining an ArgumentParser, since that messes
+    with pytest's own ArgumentParser.
+    """
+
+    def __init__(self):
+        self.parser = None
+
+    def parse_args(self) -> argparse.Namespace:
+        return argparse.Namespace()


### PR DESCRIPTION
Adds support for packages to depend on one another by building packages in the right order and hosting a local APT repository with the packages that have been built so far.

Fixes #9 