### PR TITLE
Make changelogs readable and writeable

### DIFF
--- a/debutizer/changelog.py
+++ b/debutizer/changelog.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from email.utils import format_datetime
+from email.utils import format_datetime, parsedate_to_datetime
 from pathlib import Path
-from typing import List, Optional, TextIO, Union
+from typing import Dict, List, Optional, TextIO, Union
 
 from debian import changelog as deb_changelog
 
@@ -9,87 +9,183 @@ from .errors import CommandError
 from .version import Version
 
 
-class Changelog:
-    deb_obj: Optional[deb_changelog.Changelog]
-
-    def __init__(self, package_dir: Path, distribution: str, package_name: str):
-        self.deb_obj = None
-        self._package_dir = package_dir
-        self._distribution = distribution
-        self._package_name = package_name
-
-    @property
-    def version(self) -> str:
-        if self.deb_obj is None:
-            raise CommandError(
-                "No changelog data has been loaded, so the current version cannot be "
-                "determined"
-            )
-        return str(self.deb_obj.get_version())
-
-    def save(self) -> None:
-        if self.deb_obj is not None:
-            changelog_file = self._package_dir / "debian" / "changelog"
-            changelog_file.write_text(str(self.deb_obj))
-
-    def load(self) -> None:
-        changelog_file = self._package_dir / "debian" / "changelog"
-        if changelog_file.is_file():
-            with changelog_file.open("r") as f:
-                self._from_file(f)
-        else:
-            self.deb_obj = None
-
-    def _from_file(self, file_: TextIO) -> None:
-        try:
-            self.deb_obj = deb_changelog.Changelog(file_)
-        except deb_changelog.ChangelogParseError as ex:
-            raise CommandError(f"While parsing the changelog file: {ex}") from ex
-
-    def add(
+class ChangeBlock:
+    def __init__(
         self,
         *,
         version: Union[str, Version],
         urgency: str,
         changes: List[str],
-        author: str,
-        date: datetime,
-    ) -> None:
-        """Adds an entry to the top of the changelog. This is a small wrapper around
-        Changelog.new_block, filling in some fields automatically and excluding unused
-        ones, then persists the changes to the disk. Unlike Changelog.new_block, this
-        method will handle formatting, including indentation, automatically.
-
-        :param version: The new version introduced by these changes
-        :param urgency: The urgency to update
-        :param changes: A description of each new change
-        :param author: The author of these changes
-        :param date: The date of the changes
-        """
-        if self.deb_obj is None:
-            self.deb_obj = deb_changelog.Changelog()
-
-        # Ensure that the version is properly formatted
+        author: Optional[str] = None,
+        date: Optional[datetime] = None,
+        package: Optional[str] = None,
+        distribution: Optional[str] = None,
+        urgency_comment: Optional[str] = None,
+        other_pairs: Optional[Dict[str, str]] = None,
+    ):
         if isinstance(version, str):
-            version = Version.from_string(version)
+            self.version = Version.from_string(version)
+        else:
+            self.version = version
 
-        if len(changes) == 0:
-            raise CommandError("A new changelog block must have at least one change")
+        self.urgency = urgency
+        self.changes = changes
+        self.author = author
+        self.date = date
+        self.package = package
+        self.distribution = distribution
+        self.urgency_comment = urgency_comment
+        self.other_pairs = other_pairs
+
+    def serialize(self) -> deb_changelog.ChangeBlock:
+        return deb_changelog.ChangeBlock(
+            package=self.package,
+            version=str(self.version),
+            distributions=self.distribution,
+            urgency=self.urgency,
+            urgency_comment=self.urgency_comment,
+            changes=self._format_changes(),
+            author=self.author,
+            date=self._format_datetime(),
+            other_pairs=self.other_pairs,
+        )
+
+    @classmethod
+    def deserialize(cls, deb_block: deb_changelog.ChangeBlock) -> "ChangeBlock":
+        return ChangeBlock(
+            version=str(deb_block.version),
+            urgency=deb_block.urgency,
+            changes=cls._unformat_changes(deb_block.changes()),
+            author=deb_block.author,
+            date=cls._unformat_date(deb_block.date),
+            package=deb_block.package,
+            distribution=deb_block.distributions,
+            urgency_comment=deb_block.urgency_comment,
+            other_pairs=deb_block.other_pairs,
+        )
+
+    def _format_changes(self) -> List[str]:
+        """Converts the changes list into the indented, padded format expected by
+        debian-python
+        """
+        formatted = []
 
         # Give each change indentation
-        for i, change in enumerate(changes):
-            changes[i] = f"  {change}"
-        # Attempt to properly format the given change list
-        # The changes list must start and end with empty strings, unfortunately
-        changes = [""] + changes + [""]
+        for change in self.changes:
+            if len(change) > 0:
+                formatted.append(f"  {change}")
+            else:
+                # Empty lines don't traditionally have indentation
+                formatted.append(change)
 
-        self.deb_obj.new_block(
-            package=self._package_name,
-            version=str(version),
-            distributions=self._distribution,
-            urgency=urgency,
-            changes=changes,
-            author=author,
-            date=format_datetime(date),
-            encoding="utf-8",
-        )
+        # The changes list must start and end with empty strings, unfortunately
+        formatted = [""] + formatted + [""]
+
+        return formatted
+
+    @classmethod
+    def _unformat_changes(cls, deb_changes: List[str]) -> List[str]:
+        """Converts the changes list into a more usable unindented, un-padded format"""
+        output = []
+
+        # Remove the top and bottom padding lines
+        if len(deb_changes) > 0:
+            if deb_changes[0].strip() == "":
+                deb_changes.pop(0)
+            if deb_changes[-1].strip() == "":
+                deb_changes.pop(-1)
+
+        for change in deb_changes:
+            # TODO: Are changelog files allowed to have differently sized indentation?
+            output.append(change[2:])
+
+        return output
+
+    def _format_datetime(self) -> Optional[str]:
+        """Converts the datetime into an RFC 2822 formatted string expected by
+        debian-python
+        """
+        if self.date is None:
+            return None
+        return format_datetime(self.date)
+
+    @classmethod
+    def _unformat_date(cls, date: Optional[str]) -> Optional[datetime]:
+        """Converts an RFC 2822 formatted string to a datetime"""
+        if date is None:
+            return date
+        return parsedate_to_datetime(date)
+
+
+class Changelog:
+    def __init__(self, package_dir: Path, distribution: str, package: str):
+        self._package_dir = package_dir
+        self._distribution = distribution
+        self._package = package
+
+        self.blocks: List[ChangeBlock] = []
+
+    @property
+    def version(self) -> str:
+        if len(self.blocks) == 0:
+            raise CommandError(
+                "No changelog data has been loaded, so the current version cannot be "
+                "determined"
+            )
+        return str(self.blocks[0].version)
+
+    def save(self) -> None:
+        if len(self.blocks) == 0:
+            return
+
+        deb_obj = deb_changelog.Changelog()
+
+        # The block order must be reversed because `new_block` appends entries
+        # to the top of the changelog, not the bottom
+        for block in reversed(self.blocks):
+            deb_block = block.serialize()
+            deb_obj.new_block(
+                package=deb_block.package,
+                version=deb_block.version,
+                distributions=deb_block.distributions,
+                urgency=deb_block.urgency,
+                urgency_comment=deb_block.urgency_comment,
+                changes=deb_block.changes(),
+                author=deb_block.author,
+                date=deb_block.date,
+                other_pairs=deb_block.other_pairs,
+                encoding="utf-8",
+            )
+
+        changelog_file = self._package_dir / self.FILE_PATH
+        changelog_file.write_text(str(deb_obj))
+
+    def load(self) -> None:
+        changelog_file = self._package_dir / self.FILE_PATH
+        if changelog_file.is_file():
+            with changelog_file.open("r") as f:
+                self._from_file(f)
+
+    def _from_file(self, file_: TextIO) -> None:
+        try:
+            deb_obj = deb_changelog.Changelog(file_)
+        except deb_changelog.ChangelogParseError as ex:
+            raise CommandError(f"While parsing the changelog file: {ex}") from ex
+
+        for deb_block in deb_obj:
+            block = ChangeBlock.deserialize(deb_block)
+            self.blocks.append(block)
+
+    def add(self, block: ChangeBlock) -> None:
+        """Adds an entry to the top of the changelog"""
+        if len(block.changes) == 0:
+            raise CommandError("A new changelog block must have at least one change")
+
+        if block.distribution is None:
+            block.distribution = self._distribution
+        if block.package is None:
+            block.package = self._package
+
+        self.blocks.insert(0, block)
+
+    FILE_PATH = Path("debian/changelog")

--- a/tests/resources/git_upstreams/libva/package.py
+++ b/tests/resources/git_upstreams/libva/package.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from debutizer.changelog import ChangeBlock
 from debutizer.environment import Environment
 from debutizer.source_package import SourcePackage
 from debutizer.upstreams import GitUpstream
@@ -19,11 +20,13 @@ def create_source_package(env: Environment) -> SourcePackage:
     source_package = SourcePackage(env, package_dir)
 
     source_package.changelog.add(
-        version="2.7.0-2myorg1",
-        urgency="medium",
-        changes=["* Repackaged this in my repository!"],
-        author="Tyler Compton <xaviosx@gmail.com>",
-        date=datetime(2021, 10, 8, 16, 21),
+        ChangeBlock(
+            version="2.7.0-2myorg1",
+            urgency="medium",
+            changes=["* Repackaged this in my repository!"],
+            author="Tyler Compton <xaviosx@gmail.com>",
+            date=datetime(2021, 10, 8, 16, 21),
+        )
     )
 
     return source_package

--- a/tests/resources/local_upstreams/debutizer/package.py
+++ b/tests/resources/local_upstreams/debutizer/package.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 
 from debutizer.binary_paragraph import BinaryParagraph
+from debutizer.changelog import ChangeBlock
 from debutizer.copyright import (
     Copyright,
     CopyrightFiles,
@@ -101,11 +102,13 @@ def create_source_package(env: Environment) -> SourcePackage:
     source_package.set_debhelper_compat_version()
 
     source_package.changelog.add(
-        version="0.12.1-1",
-        urgency="medium",
-        changes=["* Some changelog entry"],
-        author="Tyler Compton <xaviosx@gmail.com>",
-        date=datetime(2021, 11, 8, 23, 59),
+        ChangeBlock(
+            version="0.12.1-1",
+            urgency="medium",
+            changes=["* Some changelog entry"],
+            author="Tyler Compton <xaviosx@gmail.com>",
+            date=datetime(2021, 11, 8, 23, 59),
+        )
     )
 
     return source_package

--- a/tests/resources/source_package_upstreams/silversearcher-ag/package.py
+++ b/tests/resources/source_package_upstreams/silversearcher-ag/package.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from debutizer.changelog import ChangeBlock
 from debutizer.environment import Environment
 from debutizer.source_package import SourcePackage
 from debutizer.upstreams import SourcePackageUpstream
@@ -18,16 +19,18 @@ def create_source_package(env: Environment) -> SourcePackage:
     source_package = SourcePackage(env, package_dir)
 
     source_package.changelog.add(
-        version="2.2.0-1myorg1",
-        urgency="medium",
-        changes=[
-            "* Repackaged this in my repository!",
-            "  * Example of an indented bullet point",
-            "* This method will add indentation if you leave it out",
-            "* You don't need to worry about adding spacing on the top and bottom",
-        ],
-        author="Tyler Compton <xaviosx@gmail.com>",
-        date=datetime(2021, 10, 7, 14, 24),
+        ChangeBlock(
+            version="2.2.0-1myorg1",
+            urgency="medium",
+            changes=[
+                "* Repackaged this in my repository!",
+                "  * Example of an indented bullet point",
+                "* This method will add indentation if you leave it out",
+                "* You don't need to worry about adding spacing on the top and bottom",
+            ],
+            author="Tyler Compton <xaviosx@gmail.com>",
+            date=datetime(2021, 10, 7, 14, 24),
+        )
     )
 
     return source_package

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -1,0 +1,119 @@
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from debutizer.changelog import ChangeBlock, Changelog
+
+
+def test_changelog_retains_everything():
+    """Tests that, after being parsed and dumped back to the file system, all data and
+    formatting on the changelog is retained
+    """
+    with _package_dir() as package_dir:
+        changelog_file = package_dir / Changelog.FILE_PATH
+
+        changelog = Changelog(
+            package_dir=package_dir, distribution="unstable", package="gstreamer1.0"
+        )
+        changelog.load()
+        changelog.save()
+
+        assert changelog_file.read_text() == _CHANGELOG_STR
+
+
+def test_changelog_latest_version():
+    """Tests that the changelog consults the top entry for the latest version"""
+    with _package_dir() as package_dir:
+        changelog = Changelog(
+            package_dir=package_dir, distribution="unstable", package="gstreamer1.0"
+        )
+        changelog.load()
+
+        assert changelog.version == "1.18.4-1"
+
+
+def test_changelog_defaults():
+    """Tests that changelog blocks can be added without some fields, and that those
+    fields will be filled in by defaults given to the Changelog object
+    """
+    changelog = Changelog(
+        package_dir=Path(""), distribution="focal", package="libtoocool"
+    )
+
+    # Add an entry with the distribution and package name defined, where defaults should
+    # not be used
+    changelog.add(
+        ChangeBlock(
+            version="0.9.0-1",
+            urgency="medium",
+            changes=[
+                "* Fix race condition when parsing multiple streams with the same name"
+            ],
+            author="Mr. Developer Man <devman@seriouscompany.biz>",
+            date=datetime(2002, 11, 3, 3, 0),
+            package="libtwolame",
+            distribution="bionic",
+        )
+    )
+    assert changelog.blocks[0].distribution == "bionic"
+    assert changelog.blocks[0].package == "libtwolame"
+
+    # Add an entry with no distribution or package name and ensure the defaults
+    # are used
+    changelog.add(
+        ChangeBlock(
+            version="1.0.0-1",
+            urgency="medium",
+            changes=[
+                "* Made the project name much cooler",
+            ],
+            author="Joe Cool <lilcoolj1992@yahoo.com>",
+            date=datetime(2002, 12, 25, 8, 30),
+        )
+    )
+    assert changelog.blocks[0].distribution == "focal"
+    assert changelog.blocks[0].package == "libtoocool"
+
+
+@contextmanager
+def _package_dir():
+    """Creates a temporary directory with an example changelog inside it"""
+
+    with TemporaryDirectory() as dir_str:
+        dir_ = Path(dir_str)
+        changelog_file = dir_ / Changelog.FILE_PATH
+        changelog_file.parent.mkdir()
+        changelog_file.write_text(_CHANGELOG_STR)
+
+        yield dir_
+
+
+_CHANGELOG_STR = """gstreamer1.0 (1.18.4-1) experimental; urgency=medium
+
+  [ Helmut Grohne ]
+  * Annotate Build-Depends libgmp-dev and libgsl-dev
+    <!nocheck> (Closes: #981203).
+
+  [ Marc Leeman ]
+  * New upstream version 1.18.4
+
+  [ Sebastian Dröge ]
+  * Upload to experimental.
+
+ -- Sebastian Dröge <slomo@debian.org>  Mon, 05 Apr 2021 11:13:34 +0300
+
+gstreamer1.0 (1.18.3-1) unstable; urgency=medium
+
+  * New upstream bugfix release.
+
+ -- Sebastian Dröge <slomo@debian.org>  Thu, 14 Jan 2021 09:41:36 +0200
+
+gstreamer1.0 (1.18.2-1) unstable; urgency=medium
+
+  * New upstream bugfix release.
+
+ -- Sebastian Dröge <slomo@debian.org>  Mon, 07 Dec 2020 10:00:44 +0200
+
+"""
+"""An example changelog snippet from gstreamer1.0"""


### PR DESCRIPTION
Changelog blocks now have a type representing them and are stored in a list that's made available to users. The data is only in a debian-python format when saved or loaded. This allows users to easily introspect changelog data and make more complicated edits.

Fixes #80 