### PR TITLE
Make copyrights read and writeable

### DIFF
--- a/debutizer/source_paragraph.py
+++ b/debutizer/source_paragraph.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from debian.deb822 import Sources
 
-from .deb822_schema import Deb822Schema, T
+from .deb822_schema import SOURCE, Deb822Schema, T
 from .deb822_utils import Field
 from .relation import PackageRelations
 
@@ -72,14 +72,15 @@ class SourceParagraph(Deb822Schema):
         return deb822
 
     @classmethod
-    def deserialize(cls, deb822: T) -> "SourceParagraph":
-        inputs = cls._deserialize_fields(deb822)
+    def deserialize(cls, source: SOURCE) -> "SourceParagraph":
+        inputs = cls._deserialize_fields(source)
 
         vcs_type = None
         vcs_type_value = None
-        for key in deb822:
+        # See: https://github.com/python/mypy/issues/2220
+        for key in source:  # type: ignore[attr-defined]
             if key.lower().startswith("vcs-") and key.lower() != "vcs-browser":
-                vcs_type_value = deb822[key]
+                vcs_type_value = source[key]
                 vcs_type = key.split("-")[1]
 
         return SourceParagraph(

--- a/tests/resources/local_upstreams/debutizer/package.py
+++ b/tests/resources/local_upstreams/debutizer/package.py
@@ -78,23 +78,21 @@ def create_source_package(env: Environment) -> SourcePackage:
         )
     )
 
-    source_package.copyright.set_header(
-        CopyrightHeader(
-            upstream_name="debutizer",
-            upstream_contact=["Tyler Compton <xaviosx@gmail.com>"],
-            source="https://github.com/velovix/debutizer",
-            license_="BSD-3-Clause",
-            copyright_="Copyright 2021 Tyler Compton",
-        )
+    source_package.copyright.header = CopyrightHeader(
+        upstream_name="debutizer",
+        upstream_contact=["Tyler Compton <xaviosx@gmail.com>"],
+        source="https://github.com/velovix/debutizer",
+        license_="BSD-3-Clause",
+        copyright_="Copyright 2021 Tyler Compton",
     )
-    source_package.copyright.add_files(
+    source_package.copyright.files.append(
         CopyrightFiles(
             files=["*", "debian/*"],
             copyright_="Copyright 2021 Tyler Compton",
             license_="BSD-3-Clause",
         )
     )
-    source_package.copyright.add_license(
+    source_package.copyright.licenses.append(
         CopyrightLicense(
             license_=Copyright.full_license_text("BSD-3-Clause"),
         )

--- a/tests/unit/test_copyright.py
+++ b/tests/unit/test_copyright.py
@@ -1,3 +1,7 @@
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import pytest
 from debian.deb822 import Deb822
 
@@ -12,3 +16,67 @@ def test_license_full_text_formatting(spdx_identifier: str):
     """
     deb822 = Deb822()
     deb822["License"] = Copyright.full_license_text(spdx_identifier)
+
+
+def test_copyright_retains_everything():
+    """Tests that, after being parsed and dumped back to the file system, all data and
+    formatting on the copyright is retained
+    """
+    with _package_dir() as package_dir:
+        copyright_file = package_dir / Copyright.FILE_PATH
+
+        copyright_ = Copyright(package_dir)
+
+        copyright_.load()
+        copyright_.save()
+
+        assert copyright_file.read_text() == _COPYRIGHT_STR
+
+
+@contextmanager
+def _package_dir():
+    """Creates a temporary directory with an example copyright file inside it"""
+
+    with TemporaryDirectory() as dir_str:
+        dir_ = Path(dir_str)
+        dir_.mkdir(exist_ok=True)
+        changelog_file = dir_ / Copyright.FILE_PATH
+        changelog_file.parent.mkdir(exist_ok=True)
+        changelog_file.write_text(_COPYRIGHT_STR)
+
+        yield dir_
+
+
+_COPYRIGHT_STR = """Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: GStreamer core 1.0
+Upstream-Contact:
+ gstreamer-devel@lists.freedesktop.org
+Source: http://gstreamer.freedesktop.org
+
+Files: gst/gst.c gst/gst.h gst/gst_private.h
+Copyright: 1999-2000, Erik Walthinsen <omega@cse.ogi.edu>
+License: LGPL-2+
+
+Files: libs/gst/check/libcheck/check.c
+Copyright: 2001, 2002, Arien Malec
+  2001-2002, Arien Malec
+License: LGPL-2.1+
+
+License: LGPL-2.1+
+  This package is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+  .
+  This package is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  .
+  You should have received a copy of the GNU Lesser General Public
+  License along with this package; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+  .
+  On Debian GNU/Linux systems, the complete text of the GNU Lesser General
+  Public License can be found in `/usr/share/common-licenses/LGPL'.
+"""


### PR DESCRIPTION
Copyright components are now stored stored in a way that's easily available to users. The data is only in a debian-python format when saved or loaded. This allows users to easily introspect copyright data and make more complicated edits.

Fixes #79 